### PR TITLE
Adds ability to build XML from SAXMachine models

### DIFF
--- a/lib/pbcore.rb
+++ b/lib/pbcore.rb
@@ -4,4 +4,6 @@ module PBCore
   autoload :Base,                     'pbcore/base'
   autoload :DescriptionDocument,      'pbcore/description_document'
   autoload :Identifier,               'pbcore/identifier'
+  autoload :Title,                    'pbcore/title'
+  autoload :Description,              'pbcore/description'
 end

--- a/lib/pbcore/base.rb
+++ b/lib/pbcore/base.rb
@@ -1,5 +1,46 @@
+require 'sax-machine'
+
 module PBCore
+  # TODO: decouple XML building behavior from schema-related declarations.
   class Base
     include SAXMachine
+
+    # Defines which accessor is used to get the value within an element.
+    # Here we defined it be simply :value.
+    value :value
+
+    # Defind attributes common to all PBCore elements.
+    attribute :source
+    attribute :ref
+    attribute :annotation
+    attribute :version
+
+    # Define the class interfaces for all PBCore elements.
+    class << self
+      attr_reader :build_block
+
+      # Class method to allow extended classes to declaratively the logic used
+      # to build XML using Nokogiri::XML::Builder.
+      def build_xml(&block)
+        raise ArgumentError, "#{self.class}.build_xml requires a block with one parameter" unless block_given? && block.arity == 1
+        @build_block = block
+      end
+    end
+
+    # Executes the block defined with the class method `build_xml`. Uses a
+    # Nokogiri::XML::Builder instance (either passed in or instantiated) to
+    # build the XML, and then returns the builder instance.
+    def build(builder=nil)
+      raise ArgumentError, "#{self.class}#build expects a Nokogiri::XML::Builder class, but #{builder.class} was given" unless builder.nil? || builder.is_a?(Nokogiri::XML::Builder)
+      builder ||= Nokogiri::XML::Builder.new
+      instance_exec builder, &self.class.build_block
+      builder
+    end
+
+    # Builds the xml using #build with a new instance of Nokogiri::XML::Builder
+    # and immediately calls to_xml on it.
+    def to_xml
+      build(Nokogiri::XML::Builder.new).to_xml
+    end
   end
 end

--- a/lib/pbcore/description.rb
+++ b/lib/pbcore/description.rb
@@ -1,0 +1,10 @@
+require 'pbcore/base'
+
+module PBCore
+  class Description < Base
+    build_xml do |xml|
+      attrs = { source: source }.compact
+      xml.pbcoreDescription(value, attrs)
+    end
+  end
+end

--- a/lib/pbcore/description_document.rb
+++ b/lib/pbcore/description_document.rb
@@ -4,5 +4,26 @@ require 'pbcore/identifier'
 module PBCore
   class DescriptionDocument < Base
     elements :pbcoreIdentifier, as: :identifiers, class: PBCore::Identifier
+    elements :pbcoreTitle, as: :titles, class: PBCore::Title
+    elements :pbcoreDescription, as: :descriptions, class: PBCore::Description
+
+    build_xml do |xml|
+      xml.pbcoreDescriptionDocument(namespace_attributes) do |xml|
+        identifiers.each { |identifier| identifier.build(xml) }
+        titles.each { |title| title.build(xml) }
+        descriptions.each { |description| description.build(xml) }
+      end
+    end
+
+    # NOTE: For some reason, these attributes will not parse with SAXMachine
+    # attributes.
+    # TODO: Is there a better way to set namespace attributes?
+    def namespace_attributes
+      {
+        'xmlns' => "http://pbcore.org/PBCore/PBCoreNamespace.html",
+        'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
+        'xsi:schemaLocation' => "http://pbcore.org/PBCore/PBCoreNamespace.html https://raw.githubusercontent.com/WGBH/PBCore_2.1/master/pbcore-2.1.xsd"
+      }
+    end
   end
 end

--- a/lib/pbcore/identifier.rb
+++ b/lib/pbcore/identifier.rb
@@ -1,6 +1,11 @@
+require 'pbcore/base'
+
 module PBCore
   class Identifier < Base
     value :value
-    attribute :source
+
+    build_xml do |xml|
+      xml.pbcoreIdentifier(value, source: source)
+    end
   end
 end

--- a/lib/pbcore/title.rb
+++ b/lib/pbcore/title.rb
@@ -1,0 +1,12 @@
+require 'pbcore/base'
+
+module PBCore
+  class Title < Base
+    attribute :titleType, as: :title_type
+
+    build_xml do |xml|
+      attrs = { source: source, titleType: title_type }.compact
+      xml.pbcoreTitle(value, attrs)
+    end
+  end
+end

--- a/pbcore.gemspec
+++ b/pbcore.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'equivalent-xml', '~> 0.6.0'
 
   spec.add_dependency 'sax-machine'
   spec.add_dependency 'nokogiri'

--- a/spec/fixtures/description_document.xml
+++ b/spec/fixtures/description_document.xml
@@ -1,7 +1,8 @@
-<pbcoreDescriptionDocument xmlns="http://www.pbcore.org/PBCore/PBCoreNamespace.html"
+<?xml version="1.0"?>
+<pbcoreDescriptionDocument xmlns="http://pbcore.org/PBCore/PBCoreNamespace.html"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html https://raw.githubusercontent.com/WGBH/PBCore_2.1/master/pbcore-2.1.xsd" >
-    <pbcoreIdentifier source="MCU">MCU_a0567</pbcoreIdentifier>
-    <pbcoreTitle titleType="Main" titleTypeSource="pbcoreTitle/titleType Controlled Vocabulary" titleTypeRef="http://metadataregistry.org/concept/show/id/1773.html">Death Is A Poor Man's Doctor</pbcoreTitle>
-    <pbcoreDescription>Interviews from Detroit musicians</pbcoreDescription>
+    xsi:schemaLocation="http://pbcore.org/PBCore/PBCoreNamespace.html https://raw.githubusercontent.com/WGBH/PBCore_2.1/master/pbcore-2.1.xsd">
+    <pbcoreIdentifier source="NOLA Code">AMEX000102</pbcoreIdentifier>
+    <pbcoreTitle titleType="Full">American Experience: Radio Bikini</pbcoreTitle>
+    <pbcoreDescription>In July 1946, the U.S. Navy staged "Operation Crossroads"--two highly publicized atomic bomb tests at a Pacific Island called Bikini.  This film is the story of those tests and their effect not only on the thousands of Naval personnel and spectators who watched, but also on the Bikinians whose homes was rendered uninhabitable by contamination, even now, 40 years later.</pbcoreDescription>
 </pbcoreDescriptionDocument>

--- a/spec/pbcore/description_document_spec.rb
+++ b/spec/pbcore/description_document_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 require 'pbcore/description_document'
+require 'equivalent-xml'
 
 RSpec.describe PBCore::DescriptionDocument do
   describe '.parse' do
     let(:pbcore_xml) { fixture('description_document.xml').read }
     let(:description_document) { described_class.parse(pbcore_xml) }
     it 'parses a pbcoreDescriptionDocument' do
-      expect(description_document.identifiers.first.value).to eq 'MCU_a0567'
-      expect(description_document.identifiers.first.source).to eq 'MCU'
+      expect(description_document.identifiers.first.value).to eq 'AMEX000102'
+      expect(description_document.identifiers.first.source).to eq 'NOLA Code'
+      expect(description_document.titles.first.title_type).to eq 'Full'
+      expect(description_document.descriptions.first.value[0..33]).to eq 'In July 1946, the U.S. Navy staged'
     end
 
-    xit 'outputs the original XML' do
-      expect(description_document.to_xml).to eq pbcore_xml
+    it 'outputs the XML equivalent to what was parsed' do
+      expect(description_document.to_xml).to be_equivalent_to pbcore_xml
     end
   end
 end


### PR DESCRIPTION
* Adds class method .build_xml to base class. This method takes a block which
  acts in the same way as a block passed to Nokogiri::XML::Builder.new. This
  allows each class representing a PBCore element to be only concerned with
  building its own part of the XML document.
* Adds classes PBCore::Title and PBCore::Description to represent the
  <pbcoreTitle> and <pbcoreDescription> elements.
* Adds specs for PBCore::DescriptionDocument that test parsing and re-building
  XML.