### PR TITLE
Adds a namespace for pbcore attributes

### DIFF
--- a/lib/pbcore.rb
+++ b/lib/pbcore.rb
@@ -1,7 +1,9 @@
 require "pbcore/version"
+require "pbcore/errors"
 
 module PBCore
-  autoload :Base,                     'pbcore/base'
+  autoload :Element,                  'pbcore/element'
+  autoload :Attributes,               'pbcore/attributes'
   autoload :DescriptionDocument,      'pbcore/description_document'
   autoload :Identifier,               'pbcore/identifier'
   autoload :Title,                    'pbcore/title'

--- a/lib/pbcore/attributes.rb
+++ b/lib/pbcore/attributes.rb
@@ -1,0 +1,5 @@
+module PBCore
+  module Attributes
+    autoload :Common,       'pbcore/attributes/common'
+  end
+end

--- a/lib/pbcore/attributes/common.rb
+++ b/lib/pbcore/attributes/common.rb
@@ -1,0 +1,10 @@
+module PBCore
+  module Attributes
+    module Common
+      def self.included(base)
+        PBCore.fail_if_base_is_not_pbcore_element(included_module: self, base: base)
+        base.attribute :source
+      end
+    end
+  end
+end

--- a/lib/pbcore/description.rb
+++ b/lib/pbcore/description.rb
@@ -1,7 +1,7 @@
-require 'pbcore/base'
+require 'pbcore/element'
 
 module PBCore
-  class Description < Base
+  class Description < Element
     build_xml do |xml|
       attrs = { source: source }.compact
       xml.pbcoreDescription(value, attrs)

--- a/lib/pbcore/description_document.rb
+++ b/lib/pbcore/description_document.rb
@@ -1,8 +1,7 @@
-require 'sax-machine'
-require 'pbcore/identifier'
+require 'pbcore/element'
 
 module PBCore
-  class DescriptionDocument < Base
+  class DescriptionDocument < Element
     elements :pbcoreIdentifier, as: :identifiers, class: PBCore::Identifier
     elements :pbcoreTitle, as: :titles, class: PBCore::Title
     elements :pbcoreDescription, as: :descriptions, class: PBCore::Description

--- a/lib/pbcore/element.rb
+++ b/lib/pbcore/element.rb
@@ -2,8 +2,9 @@ require 'sax-machine'
 
 module PBCore
   # TODO: decouple XML building behavior from schema-related declarations.
-  class Base
+  class Element
     include SAXMachine
+    include PBCore::Attributes::Common
 
     # Defines which accessor is used to get the value within an element.
     # Here we defined it be simply :value.

--- a/lib/pbcore/errors.rb
+++ b/lib/pbcore/errors.rb
@@ -1,0 +1,45 @@
+# PBCore Error classes and methods.
+#
+# The classes and methods in this file intend to serve the following purposes:
+#
+#  1) Provide a base class for all PBCore errors, to that host applications can
+#     easily rescue from all errors thrown by this gem.
+#  2) Provide specific error classes, with specific error messages, for specific
+#     situations. This helps developers of host applications to quickly solve
+#     bugs they may encounter when using the gem.
+#  3) Provide module specific module methods that will:
+#     a) encapsulate conditional logic for specific situaitons
+#     b) raise specific errors
+#
+# New error classes should be created as new error conditions for specific
+# situations arise. The pattern to follow should be:
+#
+#   1) Create a new error class that extends PBCore::Error.
+#   2) The error class should be named in a way that indicates the specific
+#      situation.
+#   3) The constructor of the error class should use named arguments, and include
+#      all information necessary to provide a detailed error message to
+#      developers, ideally with some kind of instruction on how to correct the
+#      problem.
+#   3) A module method should be created to encapsulate the logic need to
+#      determine if an error should be raised.
+#   4) The module name should beging with "fail_if_" or "fail_unless_", followed
+#      by the snake-case name of the specific error class to be raised.
+#   5) The module method should test the condition, and raise the specific
+#      error. This implies that the module method must also receive all
+#      information necessary to pass along to the constructor of the error
+#      class.
+
+module PBCore
+  class Error < StandardError; end
+
+  class BaseIsNotPBCoreElement < Error
+    def initialize(included_module:, base:)
+      super("#{included_module} should only be included in PBCore::Element, but was included in #{base} (ancestors are: #{base.ancestors.join(', ')})")
+    end
+  end
+
+  def self.fail_if_base_is_not_pbcore_element(included_module:, base:)
+    raise BaseIsNotPBCoreElement.new(included_module: included_module, base: base) unless base.ancestors.include? PBCore::Element
+  end
+end

--- a/lib/pbcore/identifier.rb
+++ b/lib/pbcore/identifier.rb
@@ -1,7 +1,7 @@
-require 'pbcore/base'
+require 'pbcore/element'
 
 module PBCore
-  class Identifier < Base
+  class Identifier < Element
     value :value
 
     build_xml do |xml|

--- a/lib/pbcore/title.rb
+++ b/lib/pbcore/title.rb
@@ -1,7 +1,7 @@
-require 'pbcore/base'
+require 'pbcore/element'
 
 module PBCore
-  class Title < Base
+  class Title < Element
     attribute :titleType, as: :title_type
 
     build_xml do |xml|


### PR DESCRIPTION
Many attributes are commonly shared between elements. This provides a pattern
for allowing easier inclusion of common attributes accross multiple element
classes.

Also...

* Adds errors.rb, which outlines a framework for providing specific error for
  specific error conditions. As a first example, we don't want to allow
  inclusion any of the modules under PBCore::Attributes into any class that
  isn't a PBCore::Element, otherwise it can lead to confusing errors for
  developers. So here we add a specific error class for that condition, and a
  specific module method for testing the error condition, and raising the error
  as needed.

* Renames PBCore::Base to PBCore::Element. This makes it clearer that classes
  that extend PBCore::Element are classes are supposed to represent PBCore
  elements.