### PR TITLE
Adds shared specs for all pbcore elements

### DIFF
--- a/lib/pbcore.rb
+++ b/lib/pbcore.rb
@@ -1,7 +1,9 @@
 require "pbcore/version"
+require "pbcore/errors"
 
 module PBCore
-  autoload :Base,                     'pbcore/base'
+  autoload :Element,                  'pbcore/element'
+  autoload :Attributes,               'pbcore/attributes'
   autoload :DescriptionDocument,      'pbcore/description_document'
   autoload :Identifier,               'pbcore/identifier'
   autoload :Title,                    'pbcore/title'

--- a/lib/pbcore/attributes.rb
+++ b/lib/pbcore/attributes.rb
@@ -1,0 +1,5 @@
+module PBCore
+  module Attributes
+    autoload :Common,       'pbcore/attributes/common'
+  end
+end

--- a/lib/pbcore/attributes/common.rb
+++ b/lib/pbcore/attributes/common.rb
@@ -1,0 +1,10 @@
+module PBCore
+  module Attributes
+    module Common
+      def self.included(base)
+        PBCore.fail_if_base_is_not_pbcore_element(included_module: self, base: base)
+        base.attribute :source
+      end
+    end
+  end
+end

--- a/lib/pbcore/description.rb
+++ b/lib/pbcore/description.rb
@@ -1,7 +1,7 @@
-require 'pbcore/base'
+require 'pbcore/element'
 
 module PBCore
-  class Description < Base
+  class Description < Element
     build_xml do |xml|
       attrs = { source: source }.compact
       xml.pbcoreDescription(value, attrs)

--- a/lib/pbcore/description_document.rb
+++ b/lib/pbcore/description_document.rb
@@ -1,8 +1,7 @@
-require 'sax-machine'
-require 'pbcore/identifier'
+require 'pbcore/element'
 
 module PBCore
-  class DescriptionDocument < Base
+  class DescriptionDocument < Element
     elements :pbcoreIdentifier, as: :identifiers, class: PBCore::Identifier
     elements :pbcoreTitle, as: :titles, class: PBCore::Title
     elements :pbcoreDescription, as: :descriptions, class: PBCore::Description

--- a/lib/pbcore/element.rb
+++ b/lib/pbcore/element.rb
@@ -2,8 +2,9 @@ require 'sax-machine'
 
 module PBCore
   # TODO: decouple XML building behavior from schema-related declarations.
-  class Base
+  class Element
     include SAXMachine
+    include PBCore::Attributes::Common
 
     # Defines which accessor is used to get the value within an element.
     # Here we defined it be simply :value.

--- a/lib/pbcore/element.rb
+++ b/lib/pbcore/element.rb
@@ -16,16 +16,19 @@ module PBCore
     attribute :annotation
     attribute :version
 
-    # Define the class interfaces for all PBCore elements.
-    class << self
-      attr_reader :build_block
+    def attributes
+      self.class.sax_config.top_level_attributes
+    end
 
-      # Class method to allow extended classes to declaratively the logic used
-      # to build XML using Nokogiri::XML::Builder.
-      def build_xml(&block)
-        raise ArgumentError, "#{self.class}.build_xml requires a block with one parameter" unless block_given? && block.arity == 1
-        @build_block = block
-      end
+    # Returns a hash of attrubetes as the should appear in the XML.
+    def xml_attributes_hash
+      Hash[
+        attributes.map do |attr|
+          # No accessor here for attr.as, so that's why we use
+          # instance_variable_get(:@as)
+          [ attr.name, send(attr.instance_variable_get(:@as)) ]
+        end
+      ]
     end
 
     # Executes the block defined with the class method `build_xml`. Uses a
@@ -42,6 +45,18 @@ module PBCore
     # and immediately calls to_xml on it.
     def to_xml
       build.to_xml
+    end
+
+    # Define the class interfaces for all PBCore elements.
+    class << self
+      attr_reader :build_block
+
+      # Class method to allow extended classes to declaratively the logic used
+      # to build XML using Nokogiri::XML::Builder.
+      def build_xml(&block)
+        raise ArgumentError, "#{self.class}.build_xml requires a block with one parameter" unless block_given? && block.arity == 1
+        @build_block = block
+      end
     end
   end
 end

--- a/lib/pbcore/errors.rb
+++ b/lib/pbcore/errors.rb
@@ -1,0 +1,45 @@
+# PBCore Error classes and methods.
+#
+# The classes and methods in this file intend to serve the following purposes:
+#
+#  1) Provide a base class for all PBCore errors, to that host applications can
+#     easily rescue from all errors thrown by this gem.
+#  2) Provide specific error classes, with specific error messages, for specific
+#     situations. This helps developers of host applications to quickly solve
+#     bugs they may encounter when using the gem.
+#  3) Provide module specific module methods that will:
+#     a) encapsulate conditional logic for specific situaitons
+#     b) raise specific errors
+#
+# New error classes should be created as new error conditions for specific
+# situations arise. The pattern to follow should be:
+#
+#   1) Create a new error class that extends PBCore::Error.
+#   2) The error class should be named in a way that indicates the specific
+#      situation.
+#   3) The constructor of the error class should use named arguments, and include
+#      all information necessary to provide a detailed error message to
+#      developers, ideally with some kind of instruction on how to correct the
+#      problem.
+#   3) A module method should be created to encapsulate the logic need to
+#      determine if an error should be raised.
+#   4) The module name should beging with "fail_if_" or "fail_unless_", followed
+#      by the snake-case name of the specific error class to be raised.
+#   5) The module method should test the condition, and raise the specific
+#      error. This implies that the module method must also receive all
+#      information necessary to pass along to the constructor of the error
+#      class.
+
+module PBCore
+  class Error < StandardError; end
+
+  class BaseIsNotPBCoreElement < Error
+    def initialize(included_module:, base:)
+      super("#{included_module} should only be included in PBCore::Element, but was included in #{base} (ancestors are: #{base.ancestors.join(', ')})")
+    end
+  end
+
+  def self.fail_if_base_is_not_pbcore_element(included_module:, base:)
+    raise BaseIsNotPBCoreElement.new(included_module: included_module, base: base) unless base.ancestors.include? PBCore::Element
+  end
+end

--- a/lib/pbcore/identifier.rb
+++ b/lib/pbcore/identifier.rb
@@ -1,7 +1,7 @@
-require 'pbcore/base'
+require 'pbcore/element'
 
 module PBCore
-  class Identifier < Base
+  class Identifier < Element
     value :value
 
     build_xml do |xml|

--- a/lib/pbcore/identifier.rb
+++ b/lib/pbcore/identifier.rb
@@ -2,10 +2,10 @@ require 'pbcore/element'
 
 module PBCore
   class Identifier < Element
-    value :value
+    element :pbcoreIdentifier, as: :value
 
     build_xml do |xml|
-      xml.pbcoreIdentifier(value, source: source)
+      xml.pbcoreIdentifier(value, xml_attributes_hash.compact)
     end
   end
 end

--- a/lib/pbcore/title.rb
+++ b/lib/pbcore/title.rb
@@ -1,7 +1,7 @@
-require 'pbcore/base'
+require 'pbcore/element'
 
 module PBCore
-  class Title < Base
+  class Title < Element
     attribute :titleType, as: :title_type
 
     build_xml do |xml|

--- a/spec/pbcore/description_document_spec.rb
+++ b/spec/pbcore/description_document_spec.rb
@@ -3,16 +3,19 @@ require 'pbcore/description_document'
 require 'equivalent-xml'
 
 RSpec.describe PBCore::DescriptionDocument do
+  let(:pbcore_xml) { fixture('description_document.xml').read }
+  let(:description_document) { described_class.parse(pbcore_xml) }
+
   describe '.parse' do
-    let(:pbcore_xml) { fixture('description_document.xml').read }
-    let(:description_document) { described_class.parse(pbcore_xml) }
     it 'parses a pbcoreDescriptionDocument' do
       expect(description_document.identifiers.first.value).to eq 'AMEX000102'
       expect(description_document.identifiers.first.source).to eq 'NOLA Code'
       expect(description_document.titles.first.title_type).to eq 'Full'
       expect(description_document.descriptions.first.value[0..33]).to eq 'In July 1946, the U.S. Navy staged'
     end
+  end
 
+  describe '.to_xml' do
     it 'outputs the XML equivalent to what was parsed' do
       expect(description_document.to_xml).to be_equivalent_to pbcore_xml
     end

--- a/spec/pbcore/identifier_spec.rb
+++ b/spec/pbcore/identifier_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Identifier do
+  subject { described_class.new }
+
+  let(:attributes) { { source: "value of source attribute" } }
+  let(:value) { "value of element" }
+  let(:xml) { "<pbcoreIdentifier source='#{attributes[:source]}'>#{value}</pbcoreIdentifier>" }
+
+  it_behaves_like 'pbcore element'
+end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :have_sax_machine_attribute do |attr_name|
+  match do |actual|
+    actual.class.sax_config.top_level_attributes.map(&:name).include? attr_name.to_s
+  end
+end

--- a/spec/support/shared_specs/pbcore_element.rb
+++ b/spec/support/shared_specs/pbcore_element.rb
@@ -1,0 +1,43 @@
+RSpec.shared_examples "pbcore element" do
+  # This require needs to be inside the shared exmaple instead of the top of
+  # the file, idk why.
+  require 'equivalent-xml'
+
+  it 'has attributes common to all PBCore elements' do
+    expect(subject).to have_sax_machine_attribute :annotation
+    expect(subject).to have_sax_machine_attribute :ref
+    expect(subject).to have_sax_machine_attribute :source
+    expect(subject).to have_sax_machine_attribute :version
+  end
+
+  describe '.to_xml' do
+    before do
+      # Set attributes and value of the subject on those attributes and values
+      # passed into the shared spec.
+      attributes.each do |attr_name, attr_val|
+        setter = "#{attr_name}=".to_sym
+        subject.send(setter, attr_val)
+      end
+      subject.value = value
+    end
+
+    it 'produces XML after setting values and attributes' do
+      expect(subject.to_xml).to be_equivalent_to xml
+    end
+  end
+
+  describe '.parse' do
+    before { subject.parse(xml) }
+
+    it 'parses the XML into the object, setting attributes and the element value' do
+      attributes.each do |attr_name, attr_val|
+        expect(subject.send(attr_name)).to eq attr_val
+      end
+      expect(subject.value).to eq value
+    end
+  end
+
+  it 'can do a round trip with the XML using #parse and #to_xml' do
+    expect(subject.parse(xml).to_xml).to be_equivalent_to xml
+  end
+end


### PR DESCRIPTION
**WAIT!** merge https://github.com/WGBH-MLA/pbcore/pull/2 first! This PR if branched off of it.

Adds a spec for pbcoreIdentifier element, using the shared spec.

Also...
* Adds a convenience method to PBCore::Element base class for getting a hash of
  attributes with the XML attribute names (which are different than the ruby
  attributes).