### PR TITLE
Adds support for instantiation elements

### DIFF
--- a/lib/pbcore.rb
+++ b/lib/pbcore.rb
@@ -21,5 +21,6 @@ module PBCore
   autoload :Publisher,                'pbcore/publisher'
   autoload :RightsSummary,            'pbcore/rights_summary'
   autoload :Annotation,               'pbcore/annotation'
-  autoload :Extension,               'pbcore/extension'
+  autoload :Extension,                'pbcore/extension'
+  autoload :Instantiation,            'pbcore/instantiation' 
 end

--- a/lib/pbcore/instantiation.rb
+++ b/lib/pbcore/instantiation.rb
@@ -1,0 +1,66 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation < Element
+    autoload :Identifier,           'pbcore/instantiation/identifier'
+    autoload :Date,                 'pbcore/instantiation/date'
+    autoload :Dimensions,           'pbcore/instantiation/dimensions'
+    autoload :Physical,             'pbcore/instantiation/physical'
+    autoload :Digital,              'pbcore/instantiation/digital'
+    autoload :Standard,             'pbcore/instantiation/standard'
+    autoload :Location,             'pbcore/instantiation/location'
+    autoload :MediaType,            'pbcore/instantiation/media_type'
+    autoload :Generations,          'pbcore/instantiation/generations'
+    autoload :TimeStart,            'pbcore/instantiation/time_start'
+    autoload :FileSize,             'pbcore/instantiation/file_size'
+    autoload :Duration,             'pbcore/instantiation/duration'
+    autoload :DataRate,             'pbcore/instantiation/data_rate'
+    autoload :Colors,               'pbcore/instantiation/colors'
+    autoload :Tracks,               'pbcore/instantiation/tracks'
+    autoload :ChannelConfiguration, 'pbcore/instantiation/channel_configuration'
+    autoload :Language,             'pbcore/instantiation/language'
+    autoload :AlternativeModes,     'pbcore/instantiation/alternative_modes'
+
+    elements :instantiationIdentifier, as: :identifiers, class: PBCore::Instantiation::Identifier
+    elements :instantiationDate, as: :dates, class: PBCore::Instantiation::Date
+    elements :instantiationDimensions, as: :dimensions, class: PBCore::Instantiation::Dimensions
+    element  :instantiationPhysical, as: :physical, class: PBCore::Instantiation::Physical
+    element  :instantiationDigital, as: :digital, class: PBCore::Instantiation::Digital
+    element  :instantiationStandard, as: :standard, class: PBCore::Instantiation::Standard
+    element  :instantiationLocation, as: :location, class: PBCore::Instantiation::Location
+    element  :instantiationMediaType, as: :media_type, class: PBCore::Instantiation::MediaType
+    elements :instantiationGenerations, as: :generations, class: PBCore::Instantiation::Generations
+    elements :instantiationTimeStart, as: :time_starts, class: PBCore::Instantiation::TimeStart
+    element  :instantiationFileSize, as: :file_size, class: PBCore::Instantiation::FileSize
+    element  :instantiationDuration, as: :duration, class: PBCore::Instantiation::Duration
+    element  :instantiationDataRate, as: :data_rate, class: PBCore::Instantiation::DataRate
+    element  :instantiationColors, as: :colors, class: PBCore::Instantiation::Colors
+    element  :instantiationTracks, as: :tracks, class: PBCore::Instantiation::Tracks
+    element  :instantiationChannelConfiguration, as: :channel_configuration, class: PBCore::Instantiation::ChannelConfiguration
+    elements :instantiationLanguage, as: :languages, class: PBCore::Instantiation::Language
+    element  :instantiationAlternativeModes, as: :alternative_modes, class: PBCore::Instantiation::AlternativeModes
+
+    build_xml do |xml|
+      xml.pbcoreInstantiation(xml_attributes_hash.compact) do |xml|
+        identifiers.each { |identifier| identifier.build(xml) }
+        dates.each { |date| date.build(xml) }
+        dimensions.each { |dimensions_element| dimensions_element.build(xml) }
+        physical.build(xml)
+        digital.build(xml)
+        standard.build(xml)
+        location.build(xml)
+        media_type.build(xml)
+        generations.each { |generations_element| generations_element.build(xml) }
+        time_starts.each { |time_start| time_start.build(xml) }
+        file_size.build(xml)
+        duration.build(xml)
+        data_rate.build(xml)
+        colors.build(xml)
+        tracks.build(xml)
+        channel_configuration.build(xml)
+        languages.each { |language| language.build(xml) }
+        alternative_modes.build(xml)
+      end
+    end
+  end
+end

--- a/lib/pbcore/instantiation/alternative_modes.rb
+++ b/lib/pbcore/instantiation/alternative_modes.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::AlternativeModes < Element
+    element :instantiationAlternativeModes, as: :value
+
+    build_xml do |xml|
+      xml.instantiationAlternativeModes(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/channel_configuration.rb
+++ b/lib/pbcore/instantiation/channel_configuration.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::ChannelConfiguration < Element
+    element :instantiationChannelConfiguration, as: :value
+
+    build_xml do |xml|
+      xml.instantiationChannelConfiguration(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/colors.rb
+++ b/lib/pbcore/instantiation/colors.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Colors < Element
+    element :instantiationColors, as: :value
+
+    build_xml do |xml|
+      xml.instantiationColors(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/data_rate.rb
+++ b/lib/pbcore/instantiation/data_rate.rb
@@ -1,0 +1,13 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::DataRate < Element
+    element :instantiationDataRate, as: :value
+
+    attribute :unitsOfMeasure, as: :units_of_measure
+
+    build_xml do |xml|
+      xml.instantiationDataRate(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/date.rb
+++ b/lib/pbcore/instantiation/date.rb
@@ -1,0 +1,13 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Date < Element
+    element :instantiationDate, as: :value
+
+    attribute :dateType, as: :type
+
+    build_xml do |xml|
+      xml.instantiationDate(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/digital.rb
+++ b/lib/pbcore/instantiation/digital.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Digital < Element
+    element :instantiationDigital, as: :value
+
+    build_xml do |xml|
+      xml.instantiationDigital(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/dimensions.rb
+++ b/lib/pbcore/instantiation/dimensions.rb
@@ -1,0 +1,13 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Dimensions < Element
+    element :instantiationDimensions, as: :value
+
+    attribute :unitsOfMeasure, as: :units_of_measure
+
+    build_xml do |xml|
+      xml.instantiationDimensions(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/duration.rb
+++ b/lib/pbcore/instantiation/duration.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Duration < Element
+    element :instantiationDuration, as: :value
+
+    build_xml do |xml|
+      xml.instantiationDuration(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/file_size.rb
+++ b/lib/pbcore/instantiation/file_size.rb
@@ -1,0 +1,13 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::FileSize < Element
+    element :instantiationFileSize, as: :value
+
+    attribute :unitsOfMeasure, as: :units_of_measure
+
+    build_xml do |xml|
+      xml.instantiationFileSize(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/generations.rb
+++ b/lib/pbcore/instantiation/generations.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Generations < Element
+    element :instantiationGenerations, as: :value
+
+    build_xml do |xml|
+      xml.instantiationGenerations(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/identifier.rb
+++ b/lib/pbcore/instantiation/identifier.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Identifier < Element
+    element :instantiationIdentifier, as: :value
+
+    build_xml do |xml|
+      xml.instantiationIdentifier(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/language.rb
+++ b/lib/pbcore/instantiation/language.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Language < Element
+    element :instantiationLanguage, as: :value
+
+    build_xml do |xml|
+      xml.instantiationLanguage(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/location.rb
+++ b/lib/pbcore/instantiation/location.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Location < Element
+    element :instantiationLocation, as: :value
+
+    build_xml do |xml|
+      xml.instantiationLocation(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/media_type.rb
+++ b/lib/pbcore/instantiation/media_type.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::MediaType < Element
+    element :instantiationMediaType, as: :value
+
+    build_xml do |xml|
+      xml.instantiationMediaType(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/physical.rb
+++ b/lib/pbcore/instantiation/physical.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Physical < Element
+    element :instantiationPhysical, as: :value
+
+    build_xml do |xml|
+      xml.instantiationPhysical(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/standard.rb
+++ b/lib/pbcore/instantiation/standard.rb
@@ -1,0 +1,13 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Standard < Element
+    element :instantiationStandard, as: :value
+
+    attribute :profile, as: :profile
+
+    build_xml do |xml|
+      xml.instantiationStandard(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/time_start.rb
+++ b/lib/pbcore/instantiation/time_start.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::TimeStart < Element
+    element :instantiationTimeStart, as: :value
+
+    build_xml do |xml|
+      xml.instantiationMediaType(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore/instantiation/tracks.rb
+++ b/lib/pbcore/instantiation/tracks.rb
@@ -1,0 +1,11 @@
+require 'pbcore/element'
+
+module PBCore
+  class Instantiation::Tracks < Element
+    element :instantiationTracks, as: :value
+
+    build_xml do |xml|
+      xml.instantiationTracks(value, xml_attributes_hash.compact)
+    end
+  end
+end

--- a/lib/pbcore_website_qa
+++ b/lib/pbcore_website_qa
@@ -1,0 +1,8 @@
+* Some odd case links?
+
+* 404's for
+  - menu item "elements/pbcoreInstantiation", but "elements/pbcoreinstantiation" works
+  - menu item "instantiationtracks", but "instantiationTracks" works
+* malformed `</pre` tag getting displayed on instantiationphysical page.
+* examples for instantiationDimensions has "unitsofmeasure" attribute, which isn't camel-cased, but it should be.
+* is instantiationTimeStart supposed to be repeatable? Not sure what that means if there are > 1.

--- a/spec/pbcore/instantiation/alternative_modes_spec.rb
+++ b/spec/pbcore/instantiation/alternative_modes_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::AlternativeModes do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationAlternativeModes>SAP in English</instantiationAlternativeModes>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "SAP in English"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/channel_configuration_spec.rb
+++ b/spec/pbcore/instantiation/channel_configuration_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::ChannelConfiguration do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationChannelConfiguration>8-track stereo</instantiationChannelConfiguration>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "8-track stereo"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/colors_spec.rb
+++ b/spec/pbcore/instantiation/colors_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Colors do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationColors source="instantiationColors"
+                          ref="http://metadataregistry.org/conceptprop/list/concept_id/1484.html"
+                          annotation="sepia">
+       Toned
+     </instantiationColors>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values source: "instantiationColors",
+                                                          ref: "http://metadataregistry.org/conceptprop/list/concept_id/1484.html",
+                                                          annotation: "sepia"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "Toned"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/data_rate_spec.rb
+++ b/spec/pbcore/instantiation/data_rate_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::DataRate do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationDataRate unitsOfMeasure="Mbit/s">27</instantiationDataRate> '
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values units_of_measure: "Mbit/s"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "27"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/date_spec.rb
+++ b/spec/pbcore/instantiation/date_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Date do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationDate dateType="Published">2007-07-02T18:10+02:24</instantiationDate>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values type: "Published"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "2007-07-02T18:10+02:24"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/digital_spec.rb
+++ b/spec/pbcore/instantiation/digital_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Digital do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationDigital source="IANA MIME Media types"
+                           ref="http://www.iana.org/assignments/media-types/video/">
+       H264
+     </instantiationDigital>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values source: "IANA MIME Media types",
+                                                          ref: "http://www.iana.org/assignments/media-types/video/"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "H264"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/dimensions_spec.rb
+++ b/spec/pbcore/instantiation/dimensions_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Dimensions do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationDimensions unitsOfMeasure="pixels">100x200</instantiationDimensions>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values units_of_measure: "pixels"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "100x200"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/duration_spec.rb
+++ b/spec/pbcore/instantiation/duration_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Duration do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationDuration>00:56:46</instantiationDuration>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "00:56:46"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/file_size_spec.rb
+++ b/spec/pbcore/instantiation/file_size_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::FileSize do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationFileSize unitsOfMeasure="kB">125</instantiationFileSize>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values units_of_measure: "kB"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "125"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/generations_spec.rb
+++ b/spec/pbcore/instantiation/generations_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Generations do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationGenerations source="PBCore instantiationGenerations"
+                               ref="http://metadataregistry.org/concept/show/id/2372.html">
+       Sound effects
+     </instantiationGenerations>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values source: "PBCore instantiationGenerations",
+                                                          ref: "http://metadataregistry.org/concept/show/id/2372.html"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "Sound effects"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/identifier_spec.rb
+++ b/spec/pbcore/instantiation/identifier_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Identifier do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationIdentifier source="WGBH BARCODE">0000313536</instantiationIdentifier>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values source: "WGBH BARCODE"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "0000313536"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/language_spec.rb
+++ b/spec/pbcore/instantiation/language_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Language do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationLanguage source="IS0 639.2"
+                            ref="http://id.loc.gov/vocabulary/iso639-2/eng">
+       eng
+     </instantiationLanguage>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values source: "IS0 639.2",
+                                                          ref: "http://id.loc.gov/vocabulary/iso639-2/eng"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "eng"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/location_spec.rb
+++ b/spec/pbcore/instantiation/location_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Location do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationLocation>drive2/sourcefiles/20070910/458.wmv</instantiationLocation>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "drive2/sourcefiles/20070910/458.wmv"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/media_type_spec.rb
+++ b/spec/pbcore/instantiation/media_type_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::MediaType do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationMediaType source="PBCore instantiationMediaType"
+                             ref="http://metadataregistry.org/concept/show/id/1491.html">
+       Moving Image
+     </instantiationMediaType>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values source: "PBCore instantiationMediaType",
+                                                          ref: "http://metadataregistry.org/concept/show/id/1491.html"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "Moving Image"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/physical_spec.rb
+++ b/spec/pbcore/instantiation/physical_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Physical do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationPhysical>Shellac disc</instantiationPhysical>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "Shellac disc"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/standard_spec.rb
+++ b/spec/pbcore/instantiation/standard_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Standard do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationStandard source="PBCore instantiationStandard/video"
+                            ref="http://pbcore.org/vocabularies/instantiationStandard/video%23ntsc"
+                            profile="Op1a">
+       NTSC
+     </instantiationStandard>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has attribute values' do
+      expect(subject).to have_parsed_xml_attribute_values source: "PBCore instantiationStandard/video",
+                                                          ref: "http://pbcore.org/vocabularies/instantiationStandard/video%23ntsc",
+                                                          profile: "Op1a"
+    end
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "NTSC"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/time_start_spec.rb
+++ b/spec/pbcore/instantiation/time_start_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::TimeStart do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationTimeStart>00:23:30:15</instantiationTimeStart>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "00:23:30:15"
+    end
+  end
+end

--- a/spec/pbcore/instantiation/tracks_spec.rb
+++ b/spec/pbcore/instantiation/tracks_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation::Tracks do
+  subject { described_class.new }
+  let(:xml) do
+    '<instantiationTracks>1 video track, 1 audio track</instantiationTracks>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+
+    it 'has a value' do
+      expect(subject).to have_parsed_xml_value "1 video track, 1 audio track"
+    end
+  end
+end

--- a/spec/pbcore/instantiation_spec.rb
+++ b/spec/pbcore/instantiation_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Instantiation do
+  subject { described_class.new }
+  let(:xml) do
+    # TODO: use fixtures to test more complete and realistic <pbcoreInstantiation> elements
+    '<pbcoreInstantiation>
+       <instantiationIdentifier annotation="file name">news_20071211.mp3</instantiationIdentifier>
+       <instantiationIdentifier source="WGBH BARCODE">0000313536</instantiationIdentifier>
+       <instantiationDate dateType="Published">2007-07-02T18:10+02:24</instantiationDate>
+       <instantiationDate dateType="Issued">2007-06-02</instantiationDate>
+       <instantiationDimensions unitsofmeasure="pixels">100x200</instantiationDimensions>
+       <instantiationDimensions unitsofmeasure="inches">5x7</instantiationDimensions>
+       <instantiationPhysical>Shellac disc</instantiationPhysical>
+       <instantiationDigital source="IANA MIME Media types" ref="http://www.iana.org/assignments/media-types/video/">H264</instantiationDigital>
+     </pbcoreInstantiation>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has child elements' do
+      expect(subject).to have_parsed_xml_child_elements identifiers: PBCore::Instantiation::Identifier
+      expect(subject).to have_parsed_xml_child_elements dates: PBCore::Instantiation::Date
+      expect(subject).to have_parsed_xml_child_elements dimensions: PBCore::Instantiation::Dimensions
+      expect(subject).to have_parsed_xml_child_elements physical: PBCore::Instantiation::Physical
+      expect(subject).to have_parsed_xml_child_elements digital: PBCore::Instantiation::Digital
+    end
+  end
+end


### PR DESCRIPTION
Adds models and specs for the following elememts:
* PBCore::Instantiation
* PBCore::Instantiation::Identifier
* PBCore::Instantiation::Date
* PBCore::Instantiation::Dimensions
* PBCore::Instantiation::Physical
* PBCore::Instantiation::Digital
* PBCore::Instantiation::Colors
* PBCore::Instantiation::DataRate
* PBCore::Instantiation::AlternativeModes
* PBCore::Instantiation::ChannelConfiguration
* PBCore::Instantiation::Dimensions
* PBCore::Instantiation::Duration
* PBCore::Instantiation::FileSize
* PBCore::Instantiation::Generations
* PBCore::Instantiation::Language
* PBCore::Instantiation::Location
* PBCore::Instantiation::MediaType
* PBCore::Instantiation::Tracks
* PBCore::Instantiation::TimeStart
* PBCore::Instantiation::Standard

toward #5