### PR TITLE
Complete description document

### DIFF
--- a/lib/pbcore/contributor.rb
+++ b/lib/pbcore/contributor.rb
@@ -10,8 +10,8 @@ module PBCore
 
     build_xml do |xml|
       xml.pbcoreContributor(xml_attributes_hash.compact) do |xml|
-        contributor.build(xml)
-        role.build(xml)
+        contributor.build(xml) if contributor
+        role.build(xml) if role
       end
     end
   end

--- a/lib/pbcore/coverage.rb
+++ b/lib/pbcore/coverage.rb
@@ -11,8 +11,8 @@ module PBCore
 
     build_xml do |xml|
       xml.pbcoreCoverage(xml_attributes_hash.compact) do |xml|
-        coverage.build(xml)
-        type.build(xml)
+        coverage.build(xml) if coverage
+        type.build(xml) if type
       end
     end
   end

--- a/lib/pbcore/creator.rb
+++ b/lib/pbcore/creator.rb
@@ -10,8 +10,8 @@ module PBCore
 
     build_xml do |xml|
       xml.pbcoreCreator(xml_attributes_hash.compact) do |xml|
-        creator.build(xml)
-        role.build(xml)
+        creator.build(xml) if creator
+        role.build(xml) if role
       end
     end
   end

--- a/lib/pbcore/description_document.rb
+++ b/lib/pbcore/description_document.rb
@@ -5,12 +5,41 @@ module PBCore
     elements :pbcoreIdentifier, as: :identifiers, class: PBCore::Identifier
     elements :pbcoreTitle, as: :titles, class: PBCore::Title
     elements :pbcoreDescription, as: :descriptions, class: PBCore::Description
+    elements :pbcoreAssetType, as: :asset_types, class: PBCore::AssetType
+    elements :pbcoreAssetDate, as: :asset_dates, class: PBCore::AssetDate
+    elements :pbcoreSubject, as: :subjects, class: PBCore::Subject
+    elements :pbcoreGenre, as: :genres, class: PBCore::Genre
+    elements :pbcoreRelation, as: :relations, class: PBCore::Relation
+    elements :pbcoreCoverage, as: :coverages, class: PBCore::Coverage
+    elements :pbcoreAudienceLevel, as: :audience_levels, class: PBCore::AudienceLevel
+    elements :pbcoreAudienceRating, as: :audience_ratings, class: PBCore::AudienceRating
+    elements :pbcoreCreator, as: :creators, class: PBCore::Creator
+    elements :pbcoreContributor, as: :contributors, class: PBCore::Contributor
+    elements :pbcorePublisher, as: :publishers, class: PBCore::Publisher
+    elements :pbcoreRightsSummary, as: :rights_summaries, class: PBCore::RightsSummary
+    elements :pbcoreAnnotation, as: :annotations, class: PBCore::Annotation
+    elements :pbcoreExtension, as: :extensions, class: PBCore::Extension
+
 
     build_xml do |xml|
       xml.pbcoreDescriptionDocument(namespace_attributes) do |xml|
         identifiers.each { |identifier| identifier.build(xml) }
         titles.each { |title| title.build(xml) }
         descriptions.each { |description| description.build(xml) }
+        asset_types.each { |asset_type| asset_type.build(xml) }
+        asset_dates.each { |asset_date| asset_date.build(xml) }
+        subjects.each { |subject| subject.build(xml) }
+        genres.each { |genre| genre.build(xml) }
+        relations.each { |relation| relation.build(xml) }
+        coverages.each { |coverage| coverage.build(xml) }
+        audience_levels.each { |audience_level| audience_level.build(xml) }
+        audience_ratings.each { |audience_rating| audience_rating.build(xml) }
+        creators.each { |creator| creator.build(xml) }
+        contributors.each { |contributor| contributor.build(xml) }
+        publishers.each { |publisher| publisher.build(xml) }
+        rights_summaries.each { |rights_summary| rights_summary.build(xml) }
+        annotations.each { |annotation| annotation.build(xml) }
+        extensions.each { |extension| extension.build(xml) }
       end
     end
 

--- a/lib/pbcore/extension.rb
+++ b/lib/pbcore/extension.rb
@@ -10,8 +10,8 @@ module PBCore
 
     build_xml do |xml|
       xml.pbcoreExtension(xml_attributes_hash.compact) do |xml|
-        wrap.build(xml)
-        embedded.build(xml)
+        wrap.build(xml) if wrap
+        embedded.build(xml) if embedded
       end
     end
   end

--- a/lib/pbcore/extension/wrap.rb
+++ b/lib/pbcore/extension/wrap.rb
@@ -7,14 +7,16 @@ module PBCore
     autoload :Value,              'pbcore/extension/wrap/value'
 
     element :extensionElement, as: :element, class: PBCore::Extension::Wrap::Element
-    element :extensionValue, as: :value, class: PBCore::Extension::Wrap::Value
+    # Have to diverge from the naming convention here, because using just :value conflicts
+    # with special meaning for SAXMachine.
+    element :extensionValue, as: :extension_value, class: PBCore::Extension::Wrap::Value
     element :extensionAuthorityUsed, as: :authority_used, class: PBCore::Extension::Wrap::AuthorityUsed
 
     build_xml do |xml|
       xml.extensionWrap(xml_attributes_hash.compact) do |xml|
-        element.build(xml)
-        value.build(xml)
-        authority_used.build(xml)
+        element.build(xml) if element
+        extension_value.build(xml) if extension_value
+        authority_used.build(xml) if authority_used
       end
     end
   end

--- a/lib/pbcore/extension/wrap/element.rb
+++ b/lib/pbcore/extension/wrap/element.rb
@@ -5,7 +5,7 @@ module PBCore
     element :extensionAuthorityElement, as: :value
 
     build_xml do |xml|
-      xml.extensionAuthorityUsed(value, xml_attributes_hash.compact)
+      xml.extensionElement(value, xml_attributes_hash.compact)
     end
   end
 end

--- a/lib/pbcore/instantiation/essence_track.rb
+++ b/lib/pbcore/instantiation/essence_track.rb
@@ -36,19 +36,19 @@ module PBCore
 
     build_xml do |xml|
       xml.instantiationEssenceTrack(xml_attributes_hash.compact) do |xml|
-        type.build(xml)
+        type.build(xml) if type
         identifiers.each { |identifier| identifier.build(xml) }
-        standard.build(xml)
-        encoding.build(xml)
-        data_rate.build(xml)
-        frame_rate.build(xml)
-        playback_speed.build(xml)
-        sampling_rate.build(xml)
-        bit_depth.build(xml)
-        frame_size.build(xml)
-        duration.build(xml)
-        aspect_ratio.build(xml)
-        time_start.build(xml)
+        standard.build(xml) if standard
+        encoding.build(xml) if encoding
+        data_rate.build(xml) if data_rate
+        frame_rate.build(xml) if frame_rate
+        playback_speed.build(xml) if playback_speed
+        sampling_rate.build(xml) if sampling_rate
+        bit_depth.build(xml) if bit_depth
+        frame_size.build(xml) if frame_size
+        duration.build(xml) if duration
+        aspect_ratio.build(xml) if aspect_ratio
+        time_start.build(xml) if time_start
         languages.each { |language| language.build(xml) }
         annotations.each { |annotation| annotation.build(xml) }
       end

--- a/lib/pbcore/publisher.rb
+++ b/lib/pbcore/publisher.rb
@@ -10,8 +10,8 @@ module PBCore
 
     build_xml do |xml|
       xml.pbcorePublisher(xml_attributes_hash.compact) do |xml|
-        publisher.build(xml)
-        role.build(xml)
+        publisher.build(xml) if publisher
+        role.build(xml) if role
       end
     end
   end

--- a/lib/pbcore/relation.rb
+++ b/lib/pbcore/relation.rb
@@ -10,8 +10,8 @@ module PBCore
 
     build_xml do |xml|
       xml.pbcoreRelation(xml_attributes_hash.compact) do |xml|
-        type.build(xml)
-        identifier.build(xml)
+        type.build(xml) if type
+        identifier.build(xml) if identifier
       end
     end
   end

--- a/lib/pbcore/rights_summary.rb
+++ b/lib/pbcore/rights_summary.rb
@@ -10,9 +10,9 @@ module PBCore
     element :rightsLink, as: :rights_link, class: PBCore::RightsSummary::RightsLink
 
     build_xml do |xml|
-      xml.rightsSummary(xml_attributes_hash.compact) do |xml|
-        summary.build(xml)
-        link.build(xml)
+      xml.pbcoreRightsSummary(xml_attributes_hash.compact) do |xml|
+        rights_summary.build(xml) if rights_summary
+        rights_link.build(xml) if rights_link
       end
     end
   end

--- a/lib/pbcore/subject.rb
+++ b/lib/pbcore/subject.rb
@@ -9,7 +9,7 @@ module PBCore
     attribute :subjectTypeAnnotation, as: :type_annotation
 
     build_xml do |xml|
-      xml.pbcoreDescription(value, xml_attributes_hash.compact)
+      xml.pbcoreSubject(value, xml_attributes_hash.compact)
     end
   end
 end

--- a/spec/fixtures/description_document.xml
+++ b/spec/fixtures/description_document.xml
@@ -1,8 +1,45 @@
 <?xml version="1.0"?>
-<pbcoreDescriptionDocument xmlns="http://pbcore.org/PBCore/PBCoreNamespace.html"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pbcore.org/PBCore/PBCoreNamespace.html https://raw.githubusercontent.com/WGBH/PBCore_2.1/master/pbcore-2.1.xsd">
-    <pbcoreIdentifier source="NOLA Code">AMEX000102</pbcoreIdentifier>
+<pbcoreDescriptionDocument xmlns="http://pbcore.org/PBCore/PBCoreNamespace.html" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pbcore.org/PBCore/PBCoreNamespace.html https://raw.githubusercontent.com/WGBH/PBCore_2.1/master/pbcore-2.1.xsd">
+    <pbcoreIdentifier source="NOLA Code">NOVA003406</pbcoreIdentifier>
+    <pbcoreIdentifier source="blerg">Foo123</pbcoreIdentifier>
     <pbcoreTitle titleType="Full">American Experience: Radio Bikini</pbcoreTitle>
     <pbcoreDescription>In July 1946, the U.S. Navy staged "Operation Crossroads"--two highly publicized atomic bomb tests at a Pacific Island called Bikini.  This film is the story of those tests and their effect not only on the thousands of Naval personnel and spectators who watched, but also on the Bikinians whose homes was rendered uninhabitable by contamination, even now, 40 years later.</pbcoreDescription>
+    <pbcoreAssetType source="pbcoreAssetType" ref="http://metadataregistry.org/concept/show/id/1627.html">Story</pbcoreAssetType>
+    <pbcoreAssetDate>2001-02-03T09:30:01</pbcoreAssetDate>
+    <pbcoreSubject subjectType="entity" source="Library of Congress Name Authority">Smith, John, 1580-1631</pbcoreSubject>
+    <pbcoreGenre source="PBCore pbcoreGenre" ref="http://metadataregistry.org/concept/show/id/2449.html">History</pbcoreGenre>
+    <pbcoreRelation>
+        <pbcoreRelationType>Is Part Of</pbcoreRelationType>
+        <pbcoreRelationIdentifier>NOVA</pbcoreRelationIdentifier>
+    </pbcoreRelation>
+    <pbcoreCoverage>
+        <coverage source="latitude, longitude">37.2000,-76.7667</coverage>
+        <coverageType source="PBCore coverageType" ref="http://pbcore.org/vocabularies/coverageType#spatial">Spatial</coverageType>
+    </pbcoreCoverage>
+    <pbcoreAudienceLevel source="PBS Teachers" annotation="for educational use">K-2</pbcoreAudienceLevel>
+    <pbcoreAudienceRating source="MPAA Movie Ratings">G</pbcoreAudienceRating>
+    <pbcoreCreator>
+        <creator>foo</creator>
+        <creatorRole>bar</creatorRole>
+    </pbcoreCreator>
+    <pbcoreContributor>
+        <contributor>Yo-Yo Ma</contributor>
+        <contributorRole source="PBCore contributorRole" ref="http://metadataregistry.org/conceptprop/list/concept_id/1330.html">Instrumentalist</contributorRole>
+    </pbcoreContributor>
+    <pbcorePublisher>
+        <publisher>Public Broadcasting Service</publisher>
+        <publisherRole>Distributor</publisherRole>
+    </pbcorePublisher>
+    <pbcoreRightsSummary>
+    <rightsSummary source="Creative Commons" ref="http://creativecommons.org/licenses/by/3.0" version="3.0">CC BY 3.0</rightsSummary>
+        <rightsLink>www.rightsinfo.com</rightsLink>
+    </pbcoreRightsSummary>
+    <pbcoreAnnotation annotationType="foo">Voiceover replaced 20020302.</pbcoreAnnotation>
+    <pbcoreExtension>
+       <extensionWrap>
+         <extensionElement>RightsHolderName</extensionElement>
+         <extensionValue>WNET.org</extensionValue>
+         <extensionAuthorityUsed>http://www.loc.gov/standards/rights/METSRights.xsd</extensionAuthorityUsed>
+       </extensionWrap>
+     </pbcoreExtension>
 </pbcoreDescriptionDocument>

--- a/spec/pbcore/creator/creator_spec.rb
+++ b/spec/pbcore/creator/creator_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Creator::Creator do
+  subject { described_class.new }
+
+  let(:xml) do
+    '<creator>God</creator>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has parsed value' do
+      expect(subject).to have_parsed_xml_value "God"
+    end
+  end
+end

--- a/spec/pbcore/creator/role_spec.rb
+++ b/spec/pbcore/creator/role_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe PBCore::Creator::Role do
+  subject { described_class.new }
+
+  let(:xml) do
+    '<creatorRole>Almighty Diety</creatorRole>'
+  end
+
+  context 'after parsing PBCore XML' do
+    before { subject.parse(xml) }
+    it 'has parsed value' do
+      expect(subject).to have_parsed_xml_value "Almighty Diety"
+    end
+  end
+end

--- a/spec/pbcore/description_document_spec.rb
+++ b/spec/pbcore/description_document_spec.rb
@@ -11,12 +11,26 @@ RSpec.describe PBCore::DescriptionDocument do
     it 'has child elements' do
       expect(subject).to have_parsed_xml_child_elements identifiers: PBCore::Identifier,
                                                         titles: PBCore::Title,
-                                                        descriptions: PBCore::Description
+                                                        descriptions: PBCore::Description,
+                                                        asset_types: PBCore::AssetType,
+                                                        asset_dates: PBCore::AssetDate,
+                                                        subjects: PBCore::Subject,
+                                                        genres: PBCore::Genre,
+                                                        relations: PBCore::Relation,
+                                                        coverages: PBCore::Coverage,
+                                                        audience_levels: PBCore::AudienceLevel,
+                                                        audience_ratings: PBCore::AudienceRating,
+                                                        creators: PBCore::Creator,
+                                                        contributors: PBCore::Contributor,
+                                                        publishers: PBCore::Publisher,
+                                                        rights_summaries: PBCore::RightsSummary,
+                                                        annotations: PBCore::Annotation,
+                                                        extensions: PBCore::Extension
     end
 
     describe '.to_xml' do
       it 'outputs the XML equivalent to what was parsed' do
-        expect(subject.to_xml).to be_equivalent_to xml
+        expect(subject.to_xml).to be_equivalent_to(xml)
       end
     end
   end

--- a/spec/pbcore/extension_spec.rb
+++ b/spec/pbcore/extension_spec.rb
@@ -10,15 +10,13 @@ RSpec.describe PBCore::Extension do
          <extensionValue>WNET.org</extensionValue>
          <extensionAuthorityUsed>http://www.loc.gov/standards/rights/METSRights.xsd</extensionAuthorityUsed>
        </extensionWrap>
-       <extensionEmbedded>???</extensionEmbedded
      </pbcoreExtension>"
   end
 
   context 'after parsing PBCore XML' do
     before { subject.parse(xml) }
     it 'has parsed child elements' do
-      expect(subject).to have_parsed_xml_child_elements wrap: PBCore::Extension::Wrap,
-                                                        embedded: PBCore::Extension::Embedded
+      expect(subject).to have_parsed_xml_child_elements wrap: PBCore::Extension::Wrap
     end
   end
 end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -21,9 +21,20 @@ end
 
 RSpec::Matchers.define :have_parsed_xml_child_elements do |child_elements|
   match do |pbcore_element|
-    child_elements.reduce(true) do |memo, accessor_and_child_element_class|
+    child_elements.reduce(true) do |result, accessor_and_child_element_class|
       accessor, child_element_class = accessor_and_child_element_class
-      memo && Array(pbcore_element.send(accessor)).all? { |obj| obj.is_a?(child_element_class) }
+      array_of_children = Array(pbcore_element.send(accessor))
+      this_result = array_of_children.all? { |obj| obj.is_a?(child_element_class) }
+      this_result &= array_of_children.count > 0
+      unless this_result
+        @missing_child_elements ||= []
+        @missing_child_elements << child_element_class
+      end
+      result && this_result
     end
+  end
+
+  failure_message do |pbcore_element|
+    "expected #{pbcore_element} to have parsed xml child elements #{@missing_child_elements.join(', ')}"
   end
 end


### PR DESCRIPTION
* Adds to the fixture for testing a (more) complete <pbcoreDescriptionDocument>.
* Makes the error message more helpful on the have_xml_parsed_child_elements
  matcher.
* Fixes broken build block for PBCore::RightsSummary element.
* Fixes broken build block for PBCore::Subject element.
* Adds conditional guards in the build_xml blocks for all elements.

toward #5.