### PR TITLE
Fixes bug trying to build nil time_start

### DIFF
--- a/lib/pbcore/instantiation.rb
+++ b/lib/pbcore/instantiation.rb
@@ -65,7 +65,7 @@ module PBCore
         media_type.build(xml) if media_type
         generations.each { |generations_element| generations_element.build(xml) }
         file_size.build(xml) if file_size
-        time_start.build(xml)
+        time_start.build(xml) if time_start
         duration.build(xml) if duration
         data_rate.build(xml) if data_rate
         colors.build(xml) if colors

--- a/lib/pbcore/instantiation_document.rb
+++ b/lib/pbcore/instantiation_document.rb
@@ -65,7 +65,7 @@ module PBCore
         location.build(xml) if location
         media_type.build(xml) if media_type
         generations.each { |generations_element| generations_element.build(xml) }
-        time_start.build(xml)
+        time_start.build(xml) if time_start
         file_size.build(xml) if file_size
         duration.build(xml) if duration
         data_rate.build(xml) if data_rate


### PR DESCRIPTION
This came from switching time_start from multi-valued to single valued, but forgetting
the guard clause needed for building single valued elements.